### PR TITLE
Fix livereload issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     },
     "scripts": {
         "build": "webpack-cli --mode production && node pugconfig.js",
-        "build-watch": "webpack-cli --mode production --watch",
+        "build-watch": "webpack-cli --mode development --watch",
         "pug-watch": "node pugconfig.js --watch",
         "website": "node pugconfig.js",
         "check": "tslint --project tsconfig.json --force --format stylish --config tslint.json",

--- a/pugconfig.js
+++ b/pugconfig.js
@@ -49,7 +49,7 @@ function build() {
     render('index', 'index', { 'examples': examples });
 
     examples.forEach((example) => {
-        render(example.target, example.target, { 'example': example });
+        render(example.target, example.target, { 'example': example, 'watch': watch });
     });
 
     build_pending = false;

--- a/website/example.pug
+++ b/website/example.pug
@@ -28,5 +28,6 @@ html(lang = 'en')
 
     script(src = 'js/webgl-operate.js')
     script(src = example.target + '.js')
-    script(src='http://localhost:35729/livereload.js')
+    if watch
+      script(src='http://localhost:35729/livereload.js')
     include partials/foot.pug

--- a/website/partials/foot.pug
+++ b/website/partials/foot.pug
@@ -1,5 +1,3 @@
-script(src = 'js/webgl-operate.js')
-
 footer#footer.text-center Copyright &copy; 2015&thinsp;&ndash;&thinsp;2018  #[a(href = 'https://cginternals.com') CG Internals]
   br 
   small This type of website is critically endangered: static, self-hosted, single-origin, as well as tracking and cookie-free. #[a(href = 'https://cginternals.com/en/privacy-policy.html') Privacy Policy]


### PR DESCRIPTION
The deployed examples currently load slow because the page tries to load `livereload.js`, fails after 2 seconds, and only then triggers the `onload` callback of the samples.
-> only include it in watch mode.